### PR TITLE
Add name to config block and rename to jobs.yml

### DIFF
--- a/_config/jobs.yml
+++ b/_config/jobs.yml
@@ -1,4 +1,6 @@
-only:
+---
+Name: maintenancejobs
+Only:
   moduleexists: queuedjobs
 ---
 ScheduledRun:


### PR DESCRIPTION
Adding a name to the config block allows devs to use `before:` and `after:` to control priority. Also renamed to jobs.yml because we may end up with an extensions.yml which is queuedjobs independent at some stage.