### PR TITLE
Add button on gridfield that links to addons

### DIFF
--- a/css/sitesummary.css
+++ b/css/sitesummary.css
@@ -1,3 +1,7 @@
 .package-summary__title {
   display:block;
 }
+
+.gridfield-button-link {
+    margin-bottom: 12px;
+}

--- a/src/Forms/GridFieldLinkButton.php
+++ b/src/Forms/GridFieldLinkButton.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * A button that contains a link to an URL.
+ *
+ * @package forms
+ * @subpackage fields-gridfield
+ */
+
+class GridFieldLinkButton implements GridField_HTMLProvider
+{
+    /**
+     * Fragment to write the button to.
+     * @var string
+     */
+    protected $targetFragment;
+
+    /**
+     * URL link the button links out to.
+     * @var string
+     */
+    protected $link;
+
+    /**
+     * @param string $link The URL link the button links out to.
+     * @param string $targetFragment The HTML fragment to write the button into
+     */
+    public function __construct($link, $targetFragment)
+    {
+        $this->link = $link;
+        $this->targetFragment = $targetFragment;
+    }
+
+    /**
+     * Place the link button in a <p> tag above the field
+     *
+     * @param GridField $gridField
+     *
+     * @return array
+     */
+    public function getHTMLFragments($gridField)
+    {
+        $fragment = ArrayData::create([
+            'Link' => $this->link,
+            'Caption' => _t('GridFieldLinkButton.LINK_TO_ADDONS', 'Explore Addons')
+        ])->renderWith(__CLASS__);
+
+        return [$this->targetFragment => $fragment];
+    }
+}

--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -36,17 +36,24 @@ DESC
         ];
     }
 
+    /**
+     * Add a button row, including link out to the SilverStripe addons repository, and export button
+     *
+     * {@inheritdoc}
+     */
     public function getReportField()
     {
         Requirements::css('silverstripe-maintenance/css/sitesummary.css');
         $grid = parent::getReportField();
-        $grid->getConfig()
+        $config = $grid->getConfig();
+        $config->addComponents(
+            Injector::inst()->create('GridFieldButtonRow', 'before'),
+            Injector::inst()->create('GridFieldLinkButton', 'https://addons.silverstripe.org', 'buttons-before-left')
+        )
             ->getComponentByType(GridFieldExportButton::class)
-            ->setExportColumns([
-                'Title',
-                'Description',
-                'Version'
-            ]);
+            ->setExportColumns(
+                Package::create()->summaryFields()
+            );
         return $grid;
     }
 }

--- a/templates/GridFieldLinkButton.ss
+++ b/templates/GridFieldLinkButton.ss
@@ -1,0 +1,4 @@
+<a class="gridfield-button-link ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary"
+   href="$Link.ATT">
+    $Caption.XML
+</a>


### PR DESCRIPTION
Fixes #36 

Since font icons are not available in SS3, I made use of the jQuery UI icon `ui-icon-search`. 

Entwine works rather 'magically', so these changes include some workarounds. 

Looks as follows:

![image](https://user-images.githubusercontent.com/14869519/40335905-4c9799a8-5dba-11e8-82ac-74fd73203e12.png)

cc @newleeland