### PR TITLE
NEW Showing framework/CMS version on module report

### DIFF
--- a/css/sitesummary.css
+++ b/css/sitesummary.css
@@ -2,6 +2,12 @@
   display:block;
 }
 
+/* Due to a rule applied to `.cms .ss-gridfield > div` we have to be specific here */
+.cms .ss-gridfield > div.site-summary__clearfix {
+    margin: 0;
+    clear: both;
+}
+
 .gridfield-button-link {
     margin-bottom: 12px;
 }

--- a/src/Forms/GridFieldHtmlFragment.php
+++ b/src/Forms/GridFieldHtmlFragment.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Facilitates adding arbitrary HTML to grid fields
+ *
+ * @package forms
+ * @subpackage fields-gridfield
+ */
+
+class GridFieldHtmlFragment implements GridField_HTMLProvider
+{
+    /**
+     * Fragment to write the html fragment to.
+     * @var string
+     */
+    protected $targetFragment;
+
+    /**
+     * An HTML fragment to render
+     * @var string
+     */
+    protected $htmlFragment;
+
+    /**
+     * @param string $targetFragment Fragment to write the html fragment to.
+     * @param string $htmlFragment An HTML fragment to render
+     */
+    public function __construct($targetFragment, $htmlFragment)
+    {
+        $this->targetFragment = $targetFragment;
+        $this->htmlFragment = $htmlFragment;
+    }
+
+    /**
+     * @param GridField $gridField
+     * @return array
+     */
+    public function getHTMLFragments($gridField)
+    {
+        return [$this->targetFragment => $this->htmlFragment];
+    }
+}

--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -12,27 +12,14 @@ class SiteSummary extends SS_Report
         return _t(__CLASS__ . '.TITLE', 'Installed modules');
     }
 
-    public function description()
-    {
-        return _t(
-            __CLASS__ . '.DESCRIPTION',
-            <<<DESC
-Provides information about what SilverStripe modules are installed,
-giving an insight to project statistics such as how big the installation is,
-what it would take to upgrade it, and what functionality is available
-to both editors and users.
-DESC
-        );
-    }
-
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
 
         $this->beforeExtending('updateCMSFields', function (FieldList $fields) {
-            $fields->insertAfter('ReportDescription', new LiteralField(
+            $fields->unshift(new LiteralField(
                 'Version',
-                '<p><strong>' . _t(__CLASS__ . '.VERSION', 'Version: ') . $this->resolveCmsVersion() . '</strong></p>'
+                '<h3>' . _t(__CLASS__ . '.VERSION', 'Version: ') . $this->resolveCmsVersion() . '</h3>'
             ));
         });
 

--- a/templates/SiteSummary_VersionHeader.ss
+++ b/templates/SiteSummary_VersionHeader.ss
@@ -1,0 +1,2 @@
+<div class="site-summary__clearfix"></div>
+<h3>{$Title.XML}: {$Version.XML}</h3>


### PR DESCRIPTION
This adds a paragraph to display the version of SilverStripe CMS and Framework on the installed module report

Unfortunately the work done for SS3.7 is not available for providing the version so this looks at the contents of the report to find the relevant versions. It allows for extension in CWP. I tested it with an extension too:

```php
class CwpSiteSummaryExtension extends Extension
{
    public function getVersionModules()
    {
        return array(
            'cwp/cwp' => 'CWP',
            'silverstripe/cms' => 'SilverStripe CMS',
        );
    }
}
```

Resolves #35
Resolves #60 
