### PR TITLE
FIX Ensure report columns can be extended

### DIFF
--- a/src/Model/Package.php
+++ b/src/Model/Package.php
@@ -15,9 +15,9 @@ class Package extends DataObject
     ];
 
     private static $summary_fields = [
-        'Title',
-        'Description',
-        'Version',
+        'Title' => 'Title',
+        'Description' => 'Description',
+        'Version' => 'Version',
     ];
 
     /**

--- a/tests/Tasks/UpdatePackageInfoTest.php
+++ b/tests/Tasks/UpdatePackageInfoTest.php
@@ -11,7 +11,7 @@ class UpdatePackageInfoTest extends SapphireTest
     public function testGetPackageInfo()
     {
         $loader = $this->getMockBuilder(ComposerLoader::class)->setMethods(['getLock'])->getMock();
-        $loader->method('getLock')->willReturn(json_decode(<<<LOCK
+        $loader->expects($this->any())->method('getLock')->will($this->returnValue(json_decode(<<<LOCK
 {
     "packages": [
         {
@@ -22,7 +22,7 @@ class UpdatePackageInfoTest extends SapphireTest
     ]
 }
 LOCK
-        ));
+        )));
         $processor = new UpdatePackageInfo;
         $output = $processor->getPackageInfo($loader->getLock()->packages);
         $this->assertInternalType('array', $output);


### PR DESCRIPTION
$summary_fields is not used when generating this report, which in itself it OK, but we need the columns to be extensible to the other modules can add to them (as well as third party devs)