### PR TITLE
Excluding themes from Site Summary report

### DIFF
--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -1,5 +1,7 @@
 <?php
 
+use BringYourOwnIdeas\Maintenance\Tasks\UpdatePackageInfo;
+
 /**
  * A report listing all installed modules used in this site (from a cache).
  */
@@ -25,7 +27,16 @@ DESC
 
     public function sourceRecords($params)
     {
-        return Package::get()->filter('Type:StartsWith', 'silverstripe');
+        $packageList = Package::get();
+        $typeFilters = Config::inst()->get(UpdatePackageInfo::class, 'allowed_types');
+
+        if (!empty($typeFilters)) {
+            $packageList = $packageList->filter('Type', $typeFilters);
+        }
+
+        $this->extend('updateSourceRecords', $packageList);
+
+        return $packageList;
     }
 
     public function columns()

--- a/src/Tasks/UpdatePackageInfo.php
+++ b/src/Tasks/UpdatePackageInfo.php
@@ -23,6 +23,17 @@ class UpdatePackageInfo extends BuildTask
     ];
 
     /**
+     * The "types" of composer libraries that will be processed. Anything without these types will be ignored.
+     *
+     * @config
+     * @var array
+     */
+    private static $allowed_types = [
+        'silverstripe-module',
+        'silverstripe-vendormodule',
+    ];
+
+    /**
      * @var ComposerLoader
      */
     protected $composerLoader;


### PR DESCRIPTION
Resolves #52 

Updating the report to filter on specific types set my a config option. This PR will need a matching PR on https://github.com/bringyourownideas/silverstripe-composer-update-checker to remove a similar config option and use this one instead.