### PR TITLE
Updating table summary column to be clickable with a link to addons

### DIFF
--- a/css/sitesummary.css
+++ b/css/sitesummary.css
@@ -11,3 +11,19 @@
 .gridfield-button-link {
     margin-bottom: 12px;
 }
+
+.package-summary table.ss-gridfield-table tr td.col-Summary {
+    padding: 0;
+}
+
+a.package-summary__anchor {
+    color: inherit;
+    text-decoration: inherit;
+    display: block;
+    padding: 8px;
+}
+
+a.package-summary__anchor:hover, a.package-summary__anchor:active {
+    color: inherit;
+    text-decoration: inherit;
+}

--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -61,6 +61,8 @@ class SiteSummary extends SS_Report
         /** @var GridFieldConfig $config */
         $config = $grid->getConfig();
 
+        $grid->addExtraClass('package-summary');
+
         /** @var GridFieldExportButton $exportButton */
         $exportButton = $config->getComponentByType(GridFieldExportButton::class);
         $exportButton->setExportColumns(Package::create()->summaryFields());

--- a/templates/Package_summary.ss
+++ b/templates/Package_summary.ss
@@ -1,2 +1,4 @@
-<strong class="package-summary__title">$Title.XML</strong>
-<% if $Description %><span class="package-summary__description">$Description.XML</span><% end_if %>
+<a href="https://addons.silverstripe.org/add-ons/$Name.ATT" title="<%t SiteSummary.AddonsLinkTitle "View {package} on addons.silverstripe.org" package=$Title.ATT %>" class="package-summary__anchor" target="_blank" rel="noopener">
+    <strong class="package-summary__title">$Title.XML</strong>
+    <% if $Description %><span class="package-summary__description">$Description.XML</span><% end_if %>
+</a>


### PR DESCRIPTION
Resolves #32 

I added an anchor tag rather than using some existing GridField functionality because it was all implemented in javascript and there didn't seem to be any built in way to open in new tabs. IMO the anchor tag is a much nicer solution as you get the typical features like the URL showing in your browser.

This doesn't include making the whole row clickable. @clarkepaul and I spoke about this and it was recommended to have just the summary cells clickable.