### PR TITLE
NEW Adding a filter for supported/unsupported packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "php": "^5.6 || ~7.0.0 || ~7.1.0",
         "silverstripe/framework": "^3.2",
         "silverstripe/reports": "^3.2",
-        "symbiote/silverstripe-queuedjobs": "^2"
+        "symbiote/silverstripe-queuedjobs": "^2",
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/css/sitesummary.css
+++ b/css/sitesummary.css
@@ -42,3 +42,11 @@ a.package-summary__anchor:active {
     color: inherit;
     text-decoration: inherit;
 }
+
+.gridfield-dropdown-filter {
+    padding-right: 10px;
+}
+
+.gridfield-dropdown-filter button {
+    display: none;
+}

--- a/javascript/GridfieldDropdownFilter.js
+++ b/javascript/GridfieldDropdownFilter.js
@@ -1,0 +1,11 @@
+(function ($) {
+    $.entwine('ss', function ($) {
+        $('.gridfield-dropdown-filter select').entwine({
+            onchange: function() {
+                // Trigger the action when the select is changed. This clicks a hidden button that is entwined by
+                // GridField.js . This is similar to how GridFieldFilterHeader works.
+                this.parent().find('.action').click();
+            }
+        });
+    });
+})(jQuery);

--- a/src/Forms/GridFieldDropdownFilter.php
+++ b/src/Forms/GridFieldDropdownFilter.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * GridFieldDropdownFilter provides a dropdown that can be used to filter a GridField arbitrarily
+ *
+ * @package forms
+ * @subpackage fields-gridfield
+ */
+class GridFieldDropdownFilter implements GridField_HTMLProvider, GridField_ActionProvider, GridField_DataManipulator
+{
+    /**
+     * Default string used in the value http attribute on the option for all results
+     */
+    const DEFAULT_OPTION_VALUE = '_all';
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $targetFragment;
+
+    /**
+     * @var SS_List
+     */
+    protected $filterOptions;
+
+    /**
+     * @var string
+     */
+    protected $defaultOption;
+
+    /**
+     * @param string $name A name unique to this GridFieldDropdownFilter on this GridField
+     * @param string $targetFragment Fragment to write the html fragment to.
+     * @param string $defaultOption A string used as the label for the default "All results" option
+     */
+    public function __construct($name, $targetFragment, $defaultOption = null)
+    {
+        $this->name = $name;
+        $this->targetFragment = $targetFragment;
+        $this->defaultOption = $defaultOption ?: _t(__CLASS__ . '.AllResults', 'All results');
+        $this->filterOptions = ArrayList::create();
+    }
+
+    /**
+     * Add an option to the dropdown that provides a filter
+     *
+     * @param string $name
+     * @param string $title
+     * @param Closure|array $filter Either a Closure to filter a given SS_Filterable or a simple associative array will
+     *                              be used for filtering
+     * @return $this
+     */
+    public function addFilterOption($name, $title, $filter)
+    {
+        $this->filterOptions->push(compact('name', 'title', 'filter'));
+        return $this;
+    }
+
+    /**
+     * Remove a filter option with the given name
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function removeFilterOption($name)
+    {
+        $this->filterOptions->remove($this->filterOptions->find('name', $name));
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getActions($gridField)
+    {
+        return ['filter'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    {
+        if ($actionName !== 'filter') {
+            return;
+        }
+
+        if (!isset($data['filter-selection']) || $data['filter-selection'] === static::DEFAULT_OPTION_VALUE) {
+            $gridField->State->{__CLASS__ . '_' . $this->name} = null;
+        } else {
+            $gridField->State->{__CLASS__ . '_' . $this->name} = $data['filter-selection'];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    {
+        if (!$dataList instanceof SS_Filterable) {
+            throw new LogicException(__CLASS__ . ' is only compatible with SS_Filterable lists');
+        }
+
+        $filter = $gridField->State->{__CLASS__ . '_' . $this->name};
+
+        if (!$filter || !($option = $this->filterOptions->find('name', $filter))) {
+            return $dataList;
+        }
+
+        $filterSpec = $option['filter'];
+
+        if ($filterSpec instanceof Closure) {
+            return $filterSpec($dataList);
+        }
+        if (is_array($filterSpec)) {
+            foreach ($filterSpec as $key => $value) {
+                if ($dataList->canFilterBy($key)) {
+                    $dataList = $dataList->filter($key, $value);
+                }
+            }
+            return $dataList;
+        }
+
+        throw new LogicException('Invalid filter specification given');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHTMLFragments($gridField)
+    {
+        Requirements::javascript('silverstripe-maintenance/javascript/GridfieldDropdownFilter.js');
+
+        $dropdownOptions = [static::DEFAULT_OPTION_VALUE => $this->defaultOption] +
+            $this->filterOptions->map('name', 'title');
+
+        $dropdown = DropdownField::create(
+            'filter-selection',
+            null,
+            $dropdownOptions,
+            $gridField->State->{__CLASS__ . '_' . $this->name} ?: static::DEFAULT_OPTION_VALUE
+        );
+        $dropdown->addExtraClass('no-change-track');
+
+        return [
+            $this->targetFragment => ArrayData::create([
+                'Filter' => $dropdown,
+                'Action' => GridField_FormAction::create($gridField, 'filter', 'Go', 'filter', null),
+            ])->renderWith('GridFieldDropdownFilter'),
+        ];
+    }
+}

--- a/src/Model/Package.php
+++ b/src/Model/Package.php
@@ -11,6 +11,7 @@ class Package extends DataObject
         'Description' => 'Varchar(255)',
         'Version' => 'Varchar(255)',
         'Type' => 'Varchar(255)',
+        'Supported' => 'Boolean',
     ];
 
     private static $summary_fields = [

--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -70,6 +70,27 @@ class SiteSummary extends SS_Report
             'Version' => $this->resolveCmsVersion(),
         ])->renderWith('SiteSummary_VersionHeader');
 
+        /** @var GridFieldDropdownFilter $dropdownFilter */
+        $dropdownFilter = Injector::inst()->create(
+            GridFieldDropdownFilter::class,
+            'addonFilter',
+            'buttons-before-right',
+            _t(__CLASS__ . '.ShowAllModules', 'Show all modules')
+        );
+
+        $dropdownFilter->addFilterOption(
+            'supported',
+            _t(__CLASS__ . '.FilterSupported', 'Supported modules'),
+            ['Supported' => true]
+        );
+        $dropdownFilter->addFilterOption(
+            'unsupported',
+            _t(__CLASS__ . '.FilterUnsupported', 'Unsupported modules'),
+            ['Supported' => false]
+        );
+
+        $this->extend('updateDropdownFilterOptions', $dropdownFilter);
+
         $config->addComponents(
             Injector::inst()->create(GridFieldButtonRow::class, 'before'),
             Injector::inst()->create(GridFieldRefreshButton::class, 'buttons-before-left'),
@@ -78,8 +99,14 @@ class SiteSummary extends SS_Report
                 'https://addons.silverstripe.org',
                 'buttons-before-left'
             ),
+            $dropdownFilter,
             Injector::inst()->create(GridFieldHtmlFragment::class, 'header', $versionHtml)
         );
+
+        // Re-order the paginator to ensure it counts correctly.
+        $paginator = $config->getComponentByType(GridFieldPaginator::class);
+        $config->removeComponent($paginator);
+        $config->addComponent($paginator);
 
         return $grid;
     }

--- a/src/Util/SupportedAddonsLoader.php
+++ b/src/Util/SupportedAddonsLoader.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BringYourOwnIdeas\Maintenance\Util;
+
+use Convert;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request;
+use Object;
+use RuntimeException;
+
+/**
+ * Handles fetching supported addon details from addons.silverstripe.org
+ */
+class SupportedAddonsLoader extends Object
+{
+    private static $dependencies = [
+        'GuzzleClient' => '%$GuzzleHttp\Client',
+    ];
+
+    /**
+     * @var Client
+     */
+    protected $guzzleClient;
+
+    /**
+     * @return Client
+     */
+    public function getGuzzleClient()
+    {
+        return $this->guzzleClient;
+    }
+
+    /**
+     * @param Client $guzzleClient
+     * @return $this
+     */
+    public function setGuzzleClient(Client $guzzleClient)
+    {
+        $this->guzzleClient = $guzzleClient;
+        return $this;
+    }
+
+    /**
+     * Return the list of supported addons as provided by addons.silverstripe.org
+     *
+     * @return array
+     */
+    public function getAddonNames()
+    {
+        return $this->doRequest();
+    }
+
+    /**
+     * Perform an HTTP request for supported addon names
+     *
+     * @return array
+     * @throws RuntimeException When the API responds with something that's not a list of addons
+     */
+    protected function doRequest()
+    {
+        $request = new Request('GET', 'addons.silverstripe.org/api/supported-addons');
+
+        $failureMessage = 'Could not obtain information about supported addons. ';
+
+        try {
+            $response = $this->getGuzzleClient()->send($request, ['http_errors' => false]);
+        } catch (GuzzleException $exception) {
+            throw new RuntimeException($failureMessage);
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            throw new RuntimeException($failureMessage . 'Error code ' . $response->getStatusCode());
+        }
+
+        if (!in_array('application/json', $response->getHeader('Content-Type'))) {
+            throw new RuntimeException($failureMessage . 'Response is not JSON');
+        }
+
+        $responseBody = Convert::json2array($response->getBody()->getContents());
+
+        if (empty($responseBody)) {
+            throw new RuntimeException($failureMessage . 'Response could not be parsed');
+        }
+
+        if (!isset($responseBody['success']) || !$responseBody['success'] || !isset($responseBody['addons'])) {
+            throw new RuntimeException($failureMessage . 'Response returned unsuccessfully');
+        }
+
+        return $responseBody['addons'] ?: [];
+    }
+}

--- a/templates/GridFieldDropdownFilter.ss
+++ b/templates/GridFieldDropdownFilter.ss
@@ -1,0 +1,4 @@
+<div class="gridfield-dropdown-filter">
+    $Filter
+    $Action
+</div>

--- a/tests/Tasks/UpdatePackageInfoTest.php
+++ b/tests/Tasks/UpdatePackageInfoTest.php
@@ -3,34 +3,104 @@
 namespace BringYourOwnIdeas\Maintenance\Tests\Tasks;
 
 use BringYourOwnIdeas\Maintenance\Util\ComposerLoader;
+use BringYourOwnIdeas\Maintenance\Util\SupportedAddonsLoader;
+use Package;
+use PHPUnit_Framework_TestCase;
+use RuntimeException;
 use SapphireTest;
 use UpdatePackageInfoTask;
 
+/**
+ * @mixin PHPUnit_Framework_TestCase
+ */
 class UpdatePackageInfoTest extends SapphireTest
 {
+    protected $usesDatabase = true;
+
     public function testGetPackageInfo()
     {
-        $loader = $this->getMockBuilder(ComposerLoader::class)->setMethods(['getLock'])->getMock();
-        $loader->expects($this->any())->method('getLock')->will($this->returnValue(json_decode(<<<LOCK
-{
-    "packages": [
-        {
-            "name": "fake/package",
-            "description": "A faux package from a mocked composer.lock for testing purposes",
-            "version": "1.0.0"
-        }
-    ]
-}
-LOCK
-        )));
+        $lockOutput = [(object) [
+            "name" => "fake/package",
+            "description" => "A faux package from a mocked composer.lock for testing purposes",
+            "version" => "1.0.0",
+        ]];
+
         $processor = new UpdatePackageInfoTask;
-        $output = $processor->getPackageInfo($loader->getLock()->packages);
+        $output = $processor->getPackageInfo($lockOutput);
         $this->assertInternalType('array', $output);
         $this->assertCount(1, $output);
-        $this->assertSame([
+        $this->assertContains([
             "Name" => "fake/package",
             "Description" => "A faux package from a mocked composer.lock for testing purposes",
             "Version" => "1.0.0"
-        ], $output[0]);
+        ], $output);
+    }
+
+    public function testGetSupportedPackagesEchosErrors()
+    {
+        $supportedAddonsLoader = $this->getMockBuilder(SupportedAddonsLoader::class)
+            ->setMethods(['getAddonNames'])
+            ->getMock();
+
+        $supportedAddonsLoader->expects($this->once())
+            ->method('getAddonNames')
+            ->will($this->throwException(new RuntimeException('A test message')));
+
+        $task = new UpdatePackageInfoTask;
+        $task->setSupportedAddonsLoader($supportedAddonsLoader);
+
+        ob_start();
+        $task->getSupportedPackages();
+        $output = ob_get_clean();
+
+        $this->assertContains('A test message', $output);
+    }
+
+    public function testPackagesAreAddedCorrectly()
+    {
+        $task = new UpdatePackageInfoTask;
+
+        $composerLoader = $this->getMockBuilder(ComposerLoader::class)
+            ->setMethods(['getLock'])->getMock();
+        $composerLoader->expects($this->any())->method('getLock')->will($this->returnValue(json_decode(<<<LOCK
+{
+    "packages": [
+        {
+            "name": "fake/supported-package",
+            "description": "A faux package from a mocked composer.lock for testing purposes",
+            "version": "1.0.0"
+        },
+        {
+            "name": "fake/unsupported-package",
+            "description": "A faux package from a mocked composer.lock for testing purposes",
+            "version": "1.0.0"
+        }
+    ],
+    "packages-dev": null
+}
+LOCK
+        )));
+        $task->setComposerLoader($composerLoader);
+
+        $supportedAddonsLoader = $this->getMockBuilder(SupportedAddonsLoader::class)
+            ->setMethods(['getAddonNames'])
+            ->getMock();
+        $supportedAddonsLoader->expects($this->once())
+            ->method('getAddonNames')
+            ->will($this->returnValue(['fake/supported-package']));
+        $task->setSupportedAddonsLoader($supportedAddonsLoader);
+
+        $task->run(null);
+
+        $packages = Package::get();
+        $this->assertCount(2, $packages);
+
+        $package = $packages->find('Name', 'fake/supported-package');
+        $this->assertInstanceOf(Package::class, $package);
+        $this->assertEquals(1, $package->Supported);
+
+        $package = $packages->find('Name', 'fake/unsupported-package');
+        $this->assertInstanceOf(Package::class, $package);
+        $this->assertEquals(0, $package->Supported);
     }
 }

--- a/tests/Util/SupportedAddonsLoaderTest.php
+++ b/tests/Util/SupportedAddonsLoaderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BringYourOwnIdeas\Maintenance\Tests\Util;
+
+use BringYourOwnIdeas\Maintenance\Util\SupportedAddonsLoader;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit_Framework_TestCase;
+use RuntimeException;
+use SapphireTest;
+
+/**
+ * @mixin PHPUnit_Framework_TestCase
+ */
+class SupportedAddonsLoaderTest extends SapphireTest
+{
+    public function testNon200ErrorCodesAreHandled()
+    {
+        $loader = new SupportedAddonsLoader();
+        $loader->setGuzzleClient($this->getMockClient(new Response(404)));
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'Could not obtain information about supported addons. Error code 404'
+        );
+        $loader->getAddonNames();
+    }
+
+    public function testNonJsonResponsesAreHandled()
+    {
+        $loader = new SupportedAddonsLoader();
+        $loader->setGuzzleClient($this->getMockClient(new Response(
+            200,
+            ['Content-Type' => 'text/html; charset=utf-8']
+        )));
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'Could not obtain information about supported addons. Response is not JSON'
+        );
+        $loader->getAddonNames();
+    }
+
+    public function testUnsuccessfulResponsesAreHandled()
+    {
+        $loader = new SupportedAddonsLoader();
+        $loader->setGuzzleClient($this->getMockClient(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(['success' => 'false'])
+        )));
+
+        $this->setExpectedException(
+            RuntimeException::class,
+            'Could not obtain information about supported addons. Response returned unsuccessfully'
+        );
+        $loader->getAddonNames();
+    }
+
+
+    public function testAddonsAreParsedAndReturnedCorrectly()
+    {
+        $fakeAddons = ['foo/bar', 'bin/baz'];
+
+        $loader = new SupportedAddonsLoader();
+        $loader->setGuzzleClient($this->getMockClient(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(['success' => true, 'addons' => $fakeAddons])
+        )));
+
+        $addons = $loader->getAddonNames();
+
+        $this->assertSame($fakeAddons, $addons);
+    }
+
+    /**
+     * @param Response $withResponse
+     * @return Client
+     */
+    protected function getMockClient(Response $withResponse)
+    {
+        $mock = new MockHandler([
+            $withResponse
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        return new Client(['handler' => $handler]);
+    }
+}


### PR DESCRIPTION
Adds a filter to display supported/unsupported addons using information fetched from addons.silverstripe.org. This is done with a dropdown selector on the report.

See related CWP PR: silverstripe/cwp#87

There's one bit of code I'm not entirely happy with, but I couldn't really find a better solution. Currently the select box on the report has a hidden button (a `GridField_FormAction`) that is just clicked by javascript when the select changes. I couldn't seem to find any exposed API by the GridFields javascript to do this more cleanly.

Also, currently the API request for supported addons is ignoring the `Cache-Control` header sent. We can split this into another task I guess? Otherwise should we be looking for some Guzzle middleware for this or should I just implement it?

I'll rebase after any feedback fixes.

Resolves #34 