### PR TITLE
FIX pass correct parameter to badges extension hook

### DIFF
--- a/src/Model/Package.php
+++ b/src/Model/Package.php
@@ -52,11 +52,13 @@ class Package extends DataObject
      *   title is the unique string to display
      *   type is an optional class attribute (applied as a BEM modifier, by default)
      *
+     * @param array $extraBadges allow a user to include extra badges at call time
+     *
      * @return ArrayList
      */
-    public function getBadges()
+    public function getBadges($extraBadges = [])
     {
-        $badgeDefinitions = $this->badges;
+        $badgeDefinitions = array_merge($this->badges, $extraBadges);
         $badges = ArrayList::create();
         foreach ($badgeDefinitions as $title => $type) {
             $badges->push(ArrayData::create([
@@ -65,7 +67,7 @@ class Package extends DataObject
             ]));
         }
 
-        $this->extend('updateBadges', $badgeDefinitions);
+        $this->extend('updateBadges', $badges);
         return $badges;
     }
 

--- a/tests/Model/PackageTest.php
+++ b/tests/Model/PackageTest.php
@@ -43,22 +43,37 @@ class PackageTest extends SapphireTest
     public function testBadges()
     {
         $testPackage = new Package();
-        $testBadges = [
+
+        // setBadges to test
+        $setBadges = [
             'A good Badge' => 'good',
             'A typeless badge' => null
         ];
-        $testPackage->setBadges($testBadges);
-        $badgeViewData = $testPackage->getBadges();
+        $testPackage->setBadges($setBadges);
+
+        // test addBadge appends badge to the stored list
+        $addedBadgeTitle = 'Integer badge';
+        $addedBadgeValue = 3;
+        $testPackage->addBadge($addedBadgeTitle, $addedBadgeValue);
+
+        // tests adding badges via getBadges optional parameter
+        $extraBadge = ['Extra' => 'warning'];
+
+        // combine the input data to test outputs against
+        $badgeControlSample = array_merge($setBadges, [$addedBadgeTitle => $addedBadgeValue], $extraBadge);
+
+        $badgeViewData = $testPackage->getBadges($extraBadge);
 
         // Test expected data structure is correct
         $this->assertInstanceOf('ArrayList', $badgeViewData);
         $this->assertContainsOnlyInstancesOf('ArrayData', $badgeViewData->toArray());
 
         // Test that the output format is correct
-        reset($testBadges);
+        // and that all our input is output
+        reset($badgeControlSample);
         foreach ($badgeViewData as $badgeData) {
-            $title = key($testBadges);
-            $type = current($testBadges);
+            $title = key($badgeControlSample);
+            $type = current($badgeControlSample);
             $this->assertSame(
                 [
                     'Title' => $title,
@@ -66,9 +81,9 @@ class PackageTest extends SapphireTest
                 ],
                 $badgeData->toMap()
             );
-            // testBadges is a keyed array, so shift the pointer manually
+            // badgeControlSample is a keyed array, so shift the pointer manually
             // (because we can't lookup by index)
-            next($testBadges);
+            next($badgeControlSample);
         }
     }
 }


### PR DESCRIPTION
Although the function getBadges operated and returned correctly, the
extension point to hook the returned strucutre passed in the value of the
member property badges, then did nothing with the result. This resulted in
errors from extensions applied to the class expecting the parameter to be
an ArrayList they could push new badges into.