### PR TITLE
FIX Use Injector to create tasks in tests, ensures extensions can run with dependency injection

### DIFF
--- a/tests/Tasks/UpdatePackageInfoTest.php
+++ b/tests/Tasks/UpdatePackageInfoTest.php
@@ -25,7 +25,8 @@ class UpdatePackageInfoTest extends SapphireTest
             "version" => "1.0.0",
         ]];
 
-        $processor = new UpdatePackageInfoTask;
+        /** @var UpdatePackageInfoTask $processor */
+        $processor = UpdatePackageInfoTask::create();
         $output = $processor->getPackageInfo($lockOutput);
         $this->assertInternalType('array', $output);
         $this->assertCount(1, $output);
@@ -46,7 +47,8 @@ class UpdatePackageInfoTest extends SapphireTest
             ->method('getAddonNames')
             ->will($this->throwException(new RuntimeException('A test message')));
 
-        $task = new UpdatePackageInfoTask;
+        /** @var UpdatePackageInfoTask $task */
+        $task = UpdatePackageInfoTask::create();
         $task->setSupportedAddonsLoader($supportedAddonsLoader);
 
         ob_start();


### PR DESCRIPTION
Extensions such as the one coming shortly in the composer update checker module that define injector dependencies will not have them created automatically when using `new SomeTask()` - switched to using `::create()` to ensure they're created via the injector and have the necessary dependencies added.