### PR TITLE
FIX Make update button primary, add icon (SS 4.2+) for explore addons, reorder buttons

### DIFF
--- a/src/Forms/GridFieldRefreshButton.php
+++ b/src/Forms/GridFieldRefreshButton.php
@@ -61,7 +61,7 @@ class GridFieldRefreshButton implements GridField_HTMLProvider, GridField_Action
             null
         );
 
-        $button->addExtraClass('btn btn-secondary font-icon-sync');
+        $button->addExtraClass('btn btn-primary font-icon-sync');
 
         $button->setAttribute('data-check', $gridField->Link('check'));
         $button->setAttribute(

--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -2,22 +2,23 @@
 
 namespace BringYourOwnIdeas\Maintenance\Reports;
 
+use BringYourOwnIdeas\Maintenance\Forms\GridFieldDropdownFilter;
+use BringYourOwnIdeas\Maintenance\Forms\GridFieldHtmlFragment;
+use BringYourOwnIdeas\Maintenance\Forms\GridFieldLinkButton;
+use BringYourOwnIdeas\Maintenance\Forms\GridFieldRefreshButton;
 use BringYourOwnIdeas\Maintenance\Model\Package;
-use SilverStripe\Core\Config\Config;
 use BringYourOwnIdeas\Maintenance\Tasks\UpdatePackageInfoTask;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig;
-use SilverStripe\View\Requirements;
 use SilverStripe\Forms\GridField\GridFieldExportButton;
-use SilverStripe\View\ArrayData;
-use SilverStripe\Core\Injector\Injector;
-use BringYourOwnIdeas\Maintenance\Forms\GridFieldDropdownFilter;
-use BringYourOwnIdeas\Maintenance\Forms\GridFieldRefreshButton;
-use BringYourOwnIdeas\Maintenance\Forms\GridFieldLinkButton;
-use BringYourOwnIdeas\Maintenance\Forms\GridFieldHtmlFragment;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Reports\Report;
+use SilverStripe\View\ArrayData;
+use SilverStripe\View\Requirements;
 
 /**
  * A report listing all installed modules used in this site (from a cache).
@@ -98,14 +99,18 @@ class SiteSummary extends Report
                 'buttons-before-left'
             ),
             $this->getDropdownFilter(),
-            $this->getInfoLink(),
             Injector::inst()->create(GridFieldHtmlFragment::class, 'header', $versionHtml)
         );
 
-        // Re-order the paginator to ensure it counts correctly.
+        // Re-order the paginator to ensure it counts correctly, and reorder the buttons
         $paginator = $config->getComponentByType(GridFieldPaginator::class);
-        $config->removeComponent($paginator);
-        $config->addComponent($paginator);
+        $config->removeComponent($paginator)->addComponent($paginator);
+
+        $exportButton = $config->getComponentByType(GridFieldExportButton::class);
+        $config->removeComponent($exportButton)->addComponent($exportButton);
+
+        $printButton = $config->getComponentByType(GridFieldPrintButton::class);
+        $config->removeComponentsByType($printButton)->addComponent($printButton);
 
         return $grid;
     }

--- a/templates/BringYourOwnIdeas/Maintenance/Forms/GridFieldLinkButton.ss
+++ b/templates/BringYourOwnIdeas/Maintenance/Forms/GridFieldLinkButton.ss
@@ -1,4 +1,3 @@
-<a class="gridfield-button-link btn btn-secondary"
-   href="$Link.ATT" target="_blank">
+<a class="gridfield-button-link btn btn-secondary font-icon-explore-addons" href="$Link.ATT" target="_blank">
     $Caption.XML
 </a>


### PR DESCRIPTION
Resolves #81

Note that the "explore-addons" icon will only be available in SilverStripe 4.2, but @clarkepaul agreed to add it now since there are no decent alternatives at the moment.