### PR TITLE
Implementing job rescheduling for the queued job

### DIFF
--- a/src/Jobs/CheckForUpdatesJob.php
+++ b/src/Jobs/CheckForUpdatesJob.php
@@ -3,9 +3,11 @@
 namespace BringYourOwnIdeas\Maintenance\Jobs;
 
 use BringYourOwnIdeas\Maintenance\Tasks\UpdatePackageInfoTask;
-use Symbiote\QueuedJobs\Services\QueuedJob;
+use DateTime;
 use SilverStripe\Core\Injector\Injector;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * Refresh report job. Runs as a queued job.
@@ -51,5 +53,20 @@ class CheckForUpdatesJob extends AbstractQueuedJob implements QueuedJob
 
         // mark job as completed
         $this->isComplete = true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function afterComplete()
+    {
+        // Queue a new job to run in the future
+        $injector = Injector::inst();
+        $queuedJobService = $injector->get(QueuedJobService::class);
+        $startAfter = new DateTime('+24 hours');
+        $queuedJobService->queueJob(
+            $injector->create(CheckForUpdatesJob::class),
+            $startAfter->format(DateTime::ISO8601)
+        );
     }
 }


### PR DESCRIPTION
This PR makes the job that checks for installed version/updates reschedule itself after it completes. As expected, this conflicted with the way the refresh button determined whether it should display as clickable or in the "updating" state. Here's how it works after this PR:

- Currently when the build script is run the job gets queued in the normal "queued" queue
- When the job completes, it now adds itself back on the queue but indicates it should only start after 24 hours.
- The refresh button now only looks at the "immediate" queue for jobs
- If the refresh button is clicked, it will try to add the job to the immediate queue.
- Given the way the queued job service works, if the job is currently queued, it will do nothing but return the ID of the queued job
- The job descriptor is fetched, and if it is not on the immediate queue we move it to the immediate queue and ensure that it's set to start immediately
- When the job finishes it will reschedule for 24 hours again

This means that after any run (even pressing the refresh button) the next unprompted run of the job will be 24 hours after the last run.

Do you think I should add config settings for both the delay time and whether scheduling should be done at all?