### PR TITLE
FIX Set default return value for cache miss to false

### DIFF
--- a/src/Util/SupportedAddonsLoader.php
+++ b/src/Util/SupportedAddonsLoader.php
@@ -80,7 +80,7 @@ class SupportedAddonsLoader
      */
     public function getAddonNames()
     {
-        if (($addons = $this->getCache()->get('addons')) !== false) {
+        if (($addons = $this->getCache()->get('addons', false)) !== false) {
             return Convert::json2array($addons) ?: [];
         }
 


### PR DESCRIPTION
The normal default return value for a cache miss is null, which means that this logic always returns null (from the cache) instead of detecting a cache miss and hitting the API endpoint instead.