### PR TITLE
Implementing job rescheduling for the queued job

### DIFF
--- a/src/Forms/GridFieldRefreshButton.php
+++ b/src/Forms/GridFieldRefreshButton.php
@@ -181,20 +181,22 @@ class GridFieldRefreshButton implements GridField_HTMLProvider, GridField_Action
      */
     public function handleRefresh()
     {
-        if (!$this->hasActiveJob()) {
-            // Queue the job in the immediate queue
-            $job = Injector::inst()->create(CheckForUpdatesJob::class);
-            $jobDescriptorId = $this->getQueuedJobService()->queueJob($job, null, null, QueuedJob::IMMEDIATE);
+        if ($this->hasActiveJob()) {
+            return;
+        }
 
-            // Check the job descriptor on the queue
-            $jobDescriptor = QueuedJobDescriptor::get()->filter('ID', $jobDescriptorId)->first();
+        // Queue the job in the immediate queue
+        $job = Injector::inst()->create(CheckForUpdatesJob::class);
+        $jobDescriptorId = $this->getQueuedJobService()->queueJob($job, null, null, QueuedJob::IMMEDIATE);
 
-            // If the job is not immediate, change it to immediate and reschedule it to occur immediately
-            if ($jobDescriptor->JobType !== QueuedJob::IMMEDIATE) {
-                $jobDescriptor->JobType = QueuedJob::IMMEDIATE;
-                $jobDescriptor->StartAfter = null;
-                $jobDescriptor->write();
-            }
+        // Check the job descriptor on the queue
+        $jobDescriptor = QueuedJobDescriptor::get()->filter('ID', $jobDescriptorId)->first();
+
+        // If the job is not immediate, change it to immediate and reschedule it to occur immediately
+        if ($jobDescriptor->JobType !== QueuedJob::IMMEDIATE) {
+            $jobDescriptor->JobType = QueuedJob::IMMEDIATE;
+            $jobDescriptor->StartAfter = null;
+            $jobDescriptor->write();
         }
     }
 
@@ -210,7 +212,7 @@ class GridFieldRefreshButton implements GridField_HTMLProvider, GridField_Action
      * @param QueuedJobService $queuedJobService
      * @return $this
      */
-    public function setQueuedJobService($queuedJobService)
+    public function setQueuedJobService(QueuedJobService $queuedJobService)
     {
         $this->queuedJobService = $queuedJobService;
         return $this;

--- a/src/Jobs/CheckForUpdatesJob.php
+++ b/src/Jobs/CheckForUpdatesJob.php
@@ -54,7 +54,9 @@ class CheckForUpdatesJob extends AbstractQueuedJob implements QueuedJob
         // Queue a new job to run in the future
         $injector = Injector::inst();
         $queuedJobService = $injector->get(QueuedJobService::class);
-        $startAfter = new DateTime('+24 hours');
+
+        $startAfter = new DateTime(SS_Datetime::now()->getValue());
+        $startAfter->modify('+1 day');
         $queuedJobService->queueJob(
             $injector->create(CheckForUpdatesJob::class),
             $startAfter->format(DateTime::ISO8601)

--- a/src/Jobs/CheckForUpdatesJob.php
+++ b/src/Jobs/CheckForUpdatesJob.php
@@ -13,10 +13,7 @@ class CheckForUpdatesJob extends AbstractQueuedJob implements QueuedJob
      */
     public function getTitle()
     {
-        return _t(
-            'CheckForUpdates.TITLE',
-            'Check for updates to installed modules'
-        );
+        return _t(__CLASS__ . '.TITLE', 'Check for updates');
     }
 
     /**
@@ -47,5 +44,20 @@ class CheckForUpdatesJob extends AbstractQueuedJob implements QueuedJob
 
         // mark job as completed
         $this->isComplete = true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function afterComplete()
+    {
+        // Queue a new job to run in the future
+        $injector = Injector::inst();
+        $queuedJobService = $injector->get(QueuedJobService::class);
+        $startAfter = new DateTime('+24 hours');
+        $queuedJobService->queueJob(
+            $injector->create(CheckForUpdatesJob::class),
+            $startAfter->format(DateTime::ISO8601)
+        );
     }
 }

--- a/src/Jobs/CheckForUpdatesJob.php
+++ b/src/Jobs/CheckForUpdatesJob.php
@@ -7,13 +7,32 @@
 class CheckForUpdatesJob extends AbstractQueuedJob implements QueuedJob
 {
     /**
+     * Whether or not to reschedule a new job when one completes
+     *
+     * @config
+     * @var bool
+     */
+    private static $reschedule = true;
+
+    /**
+     * The PHP time difference to reschedule a job for after one completes
+     *
+     * @config
+     * @var string
+     */
+    private static $reschedule_delay = '+1 day';
+
+    /**
      * Define the title
      *
      * @return string
      */
     public function getTitle()
     {
-        return _t(__CLASS__ . '.TITLE', 'Check for updates');
+        return _t(
+            'CheckForUpdates.TITLE',
+            'Check for updates to installed modules'
+        );
     }
 
     /**
@@ -51,12 +70,20 @@ class CheckForUpdatesJob extends AbstractQueuedJob implements QueuedJob
      */
     public function afterComplete()
     {
+        // Gather config options
+        $reschedule = Config::inst()->get(__CLASS__, 'reschedule');
+        $rescheduleDelay = Config::inst()->get(__CLASS__, 'reschedule_delay');
+
+        if ($reschedule === false) {
+            return;
+        }
+
         // Queue a new job to run in the future
         $injector = Injector::inst();
         $queuedJobService = $injector->get(QueuedJobService::class);
 
         $startAfter = new DateTime(SS_Datetime::now()->getValue());
-        $startAfter->modify('+1 day');
+        $startAfter->modify($rescheduleDelay);
         $queuedJobService->queueJob(
             $injector->create(CheckForUpdatesJob::class),
             $startAfter->format(DateTime::ISO8601)

--- a/tests/Forms/GridFieldRefreshButtonTest.yml
+++ b/tests/Forms/GridFieldRefreshButtonTest.yml
@@ -3,6 +3,10 @@ QueuedJobDescriptor:
     JobStatus: 'Running'
     Implementation: 'CheckForUpdatesJob'
     JobType: 2
+  immediatependingjob:
+    JobStatus: 'Pending'
+    Implementation: 'CheckForUpdatesJob'
+    JobType: 1
   brokenjob:
     JobStatus: 'Broken'
     Implementation: 'CheckForUpdatesJob'


### PR DESCRIPTION
Was previously #93

> This PR makes the job that checks for installed version/updates reschedule itself after it completes. As expected, this conflicted with the way the refresh button determined whether it should display as clickable or in the "updating" state. Here's how it works after this PR:
> 
> - Currently when the build script is run the job gets queued in the normal "queued" queue
> - When the job completes, it now adds itself back on the queue but indicates it should only start after 24 hours.
> - The refresh button now only looks at the "immediate" queue for jobs
> - If the refresh button is clicked, it will try to add the job to the immediate queue.
> - Given the way the queued job service works, if the job is currently queued, it will do nothing but return the ID of the queued job
> - The job descriptor is fetched, and if it is not on the immediate queue we move it to the immediate queue and ensure that it's set to start immediately
> - When the job finishes it will reschedule for 24 hours again
> 
> This means that after any run (even pressing the refresh button) the next unprompted run of the job will be 24 hours after the last run.
> 
> Do you think I should add config settings for both the delay time and whether scheduling should be done at all?