### PR TITLE
Fixing jargon on printed site summary report

### DIFF
--- a/src/Reports/SiteSummary.php
+++ b/src/Reports/SiteSummary.php
@@ -66,9 +66,13 @@ class SiteSummary extends SS_Report
 
         $grid->addExtraClass('site-summary');
 
+        $summaryFields = Package::create()->summaryFields();
         /** @var GridFieldExportButton $exportButton */
         $exportButton = $config->getComponentByType(GridFieldExportButton::class);
-        $exportButton->setExportColumns(Package::create()->summaryFields());
+        $exportButton->setExportColumns($summaryFields);
+        /** @var GridFieldPrintButton $printButton */
+        $printButton = $config->getComponentByType(GridFieldPrintButton::class);
+        $printButton->setPrintColumns($summaryFields);
 
         $versionHtml = ArrayData::create([
             'Title' => _t(__CLASS__ . '.VERSION', 'Version'),


### PR DESCRIPTION
Similar to how the report is exported the print-safe version of the report will now show the title and description separately without markup

Partially addresses #96 (for v3 only)