### PR TITLE
FIX Backport queueing module update on build

### DIFF
--- a/src/Model/Package.php
+++ b/src/Model/Package.php
@@ -106,7 +106,11 @@ class Package extends DataObject
 
         $pendingJobs = QueuedJobDescriptor::get()->filter([
             'Implementation' => CheckForUpdatesJob::class,
-            'JobStatus' => QueuedJob::STATUS_NEW
+            'JobStatus' => [
+                QueuedJob::STATUS_NEW,
+                QueuedJob::STATUS_INIT,
+                QueuedJob::STATUS_RUN,
+            ],
         ]);
         if ($pendingJobs->count()) {
             return;

--- a/src/Model/Package.php
+++ b/src/Model/Package.php
@@ -117,7 +117,7 @@ class Package extends DataObject
         }
 
         /** @var QueuedJobService $jobService */
-        $jobService = QueuedJobService::singleton();
+        $jobService = Injector::inst()->get(QueuedJobService::class);
         $jobService->queueJob(Injector::inst()->create(CheckForUpdatesJob::class));
     }
 }


### PR DESCRIPTION
Mostly a cherry-pick of #91 . One extra commit as `QueuedJobService` does not extend `Object` in SS3 so `Injector` must be used directly.