### PR TITLE
NEW Adding memory limit setting 

### DIFF
--- a/src/Tasks/UpdatePackageInfoTask.php
+++ b/src/Tasks/UpdatePackageInfoTask.php
@@ -8,6 +8,13 @@ use BringYourOwnIdeas\Maintenance\Util\SupportedAddonsLoader;
  */
 class UpdatePackageInfoTask extends BuildTask
 {
+    /**
+     * A custom memory limit to set for this to increase to (or do nothing if the memory is already set high enough)
+     *
+     * @config
+     * @var string
+     */
+    private static $memory_limit = '256m';
 
     /**
      * @var array Injector configuration
@@ -101,6 +108,13 @@ class UpdatePackageInfoTask extends BuildTask
      */
     public function run($request)
     {
+        // Loading packages and all their updates can be quite memory intensive.
+        $memoryLimit = Config::inst()->get(self::class, 'memory_limit');
+        if (get_increase_memory_limit_max() < translate_memstring($memoryLimit)) {
+            set_increase_memory_limit_max($memoryLimit);
+        }
+        increase_memory_limit_to($memoryLimit);
+
         $composerLock = $this->getComposerLoader()->getLock();
         $rawPackages = array_merge($composerLock->packages, (array) $composerLock->{'packages-dev'});
         $packages = $this->getPackageInfo($rawPackages);

--- a/src/Tasks/UpdatePackageInfoTask.php
+++ b/src/Tasks/UpdatePackageInfoTask.php
@@ -110,10 +110,12 @@ class UpdatePackageInfoTask extends BuildTask
     {
         // Loading packages and all their updates can be quite memory intensive.
         $memoryLimit = Config::inst()->get(self::class, 'memory_limit');
-        if (get_increase_memory_limit_max() < translate_memstring($memoryLimit)) {
-            set_increase_memory_limit_max($memoryLimit);
+        if ($memoryLimit) {
+            if (get_increase_memory_limit_max() < translate_memstring($memoryLimit)) {
+                set_increase_memory_limit_max($memoryLimit);
+            }
+            increase_memory_limit_to($memoryLimit);
         }
-        increase_memory_limit_to($memoryLimit);
 
         $composerLock = $this->getComposerLoader()->getLock();
         $rawPackages = array_merge($composerLock->packages, (array) $composerLock->{'packages-dev'});


### PR DESCRIPTION
Adding memory limit setting (and config option) on the package update task. Defaulted to 512m because although I can get this task to run with a setting of 256M I was running that on a non-CWP installation.