### PR TITLE
FIX Guzzle Client options can be configured by extensions

### DIFF
--- a/src/Util/ApiLoader.php
+++ b/src/Util/ApiLoader.php
@@ -21,7 +21,7 @@ abstract class ApiLoader
     use Extensible;
 
     private static $dependencies = [
-        'GuzzleClient' => '%$GuzzleHttp\Client',
+        'GuzzleClient' => '%$' . Client::class,
     ];
 
     /**
@@ -62,7 +62,7 @@ abstract class ApiLoader
 
         try {
             /** @var Response $response */
-            $response = $this->getGuzzleClient()->send($request, ['http_errors' => false]);
+            $response = $this->getGuzzleClient()->send($request, $this->getClientOptions());
         } catch (GuzzleException $exception) {
             throw new RuntimeException($failureMessage);
         }
@@ -110,6 +110,20 @@ abstract class ApiLoader
     {
         $this->guzzleClient = $guzzleClient;
         return $this;
+    }
+
+    /**
+     * Get Guzzle client options
+     *
+     * @return array
+     */
+    public function getClientOptions()
+    {
+        $options = [
+            'http_errors' => false,
+        ];
+        $this->extend('updateClientOptions', $options);
+        return $options;
     }
 
     /**


### PR DESCRIPTION
In the Common Web Platform, or any other network that requires a proxy for outgoing HTTP requests, we need to configure the proxy settings before these requests get made.

Request points:

* ApiLoader to addons.silverstripe.org
* Composer Update Checker to GitHub/Packagist/other
* Security Checker to SensioLabs

This PR adds configurability to the ApiLoader, while the Update Checker can be configured using `$_SERVER['CGI_HTTP_PROXY']` and Security Checker via HTTP_PROXY and HTTPS_PROXY environment variables and will be detected automatically.

The ApiLoader uses Guzzle which needs these defined explicitly, and the update checker uses Composer which creates its own stream context, therefore also needs to be configured. Clients like CWP can define input points such as `$_SERVER['CGI_HTTP_PROXY']` _before_ the `ComposerLoaderExtension::onAfterBuild` is run which is the point that Composer is created with its config.

Probably more of a minor semver change but I'd like to treat this as a patch since it's fixing a bug and is backwards compatible.

Fixes #113 