### PR TITLE
DEP Remove security checker from suggested modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         ]
     },
     "suggest": {
-        "bringyourownideas/silverstripe-composer-security-checker": "Checks for known security vulnerabilities",
         "bringyourownideas/silverstripe-composer-update-checker": "Checks for available updates of dependencies"
     },
     "support": {


### PR DESCRIPTION
@spekulatius 

We've decided to remove `bringyourownideas/silverstripe-composer-security-checker` from the list of supported module since [it can't work any more](https://github.com/bringyourownideas/silverstripe-composer-security-checker/issues/57).

We're removing it from `silverstripe/recipe-reporting-tools` https://github.com/silverstripe/recipe-reporting-tools/pull/17

In this context, it makes sense not to suggest it when installing ` bringyourownideas/silverstripe-maintenance`.

Let us know if you have questions with this course of action.



