### PR TITLE
DEP Allow guzzle ^7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/reports": "^4.4",
         "symbiote/silverstripe-queuedjobs": "^4",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
This is necessary for various package compatibilities - for example anyone wanting to use `mindscape/raygun4php ^2`