### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/reports": "4.13.x-dev",
-        "symbiote/silverstripe-queuedjobs": "4.12.x-dev",
+        "silverstripe/framework": "^4.10",
+        "silverstripe/reports": "^4.4",
+        "symbiote/silverstripe-queuedjobs": "^4.1",
         "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33