### PR TITLE
API Deprecate API that will be removed

### DIFF
--- a/src/Tasks/UpdatePackageInfoTask.php
+++ b/src/Tasks/UpdatePackageInfoTask.php
@@ -65,6 +65,7 @@ class UpdatePackageInfoTask extends BuildTask
 
     /**
      * @var SupportedAddonsLoader
+     * @deprecated 3.3.0 Will be removed without equivalent functionality
      */
     protected $supportedAddonsLoader;
 
@@ -99,18 +100,24 @@ class UpdatePackageInfoTask extends BuildTask
 
     /**
      * @return SupportedAddonsLoader
+     * @deprecated 3.3.0 Will be removed without equivalent functionality
      */
     public function getSupportedAddonsLoader()
     {
+        Deprecation::notice('3.3.0', 'Will be removed without equivalent functionality');
         return $this->supportedAddonsLoader;
     }
 
     /**
      * @param SupportedAddonsLoader $supportedAddonsLoader
      * @return $this
+     * @deprecated 3.3.0 Will be removed without equivalent functionality
      */
     public function setSupportedAddonsLoader(SupportedAddonsLoader $supportedAddonsLoader)
     {
+        Deprecation::withNoReplacement(
+            fn() => Deprecation::notice('3.3.0', 'Will be removed without equivalent functionality')
+        );
         $this->supportedAddonsLoader = $supportedAddonsLoader;
         return $this;
     }


### PR DESCRIPTION
See https://github.com/bringyourownideas/silverstripe-maintenance/pull/239

Should have already been deprecated when the `SupportedAddonsLoader` was deprecated in `3.2.0`

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11341