### PR TITLE
MNT Fix PHPUnit 12 deprecations

### DIFF
--- a/tests/Util/ApiLoaderTest.php
+++ b/tests/Util/ApiLoaderTest.php
@@ -178,11 +178,14 @@ class ApiLoaderTest extends SapphireTest
             $cacheMock->expects($this->any())->method('set')->willReturn(true);
         }
 
-        $loader = $this->getMockBuilder(ApiLoader::class)
-            ->getMockForAbstractClass();
+        $loader = new class extends ApiLoader {
+            protected function getCacheKey()
+            {
+                return 'cacheKey';
+            }
+        };
 
         $loader->setCache($cacheMock);
-        $loader->expects($this->any())->method('getCacheKey')->willReturn('cacheKey');
 
         return $loader;
     }

--- a/tests/Util/SupportedAddonsLoaderTest.php
+++ b/tests/Util/SupportedAddonsLoaderTest.php
@@ -38,7 +38,7 @@ class SupportedAddonsLoaderTest extends SapphireTest
         $this->loader->expects($this->once())
             ->method('doRequest')
             ->with($this->isType('string'), $this->isType('callable'))
-            ->will($this->returnArgument(1));
+            ->willReturnArgument(1);
 
         $result = $this->loader->getAddonNames();
         $mockResponse = [


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/305

Fixes:

```
BringYourOwnIdeas\Maintenance\Tests\Util\ApiLoaderTest::testCachedAddonsAreUsedWhenAvailable
MockBuilder::getMockForAbstractClass() is deprecated and will be removed in PHPUnit 12 without replacement.

BringYourOwnIdeas\Maintenance\Tests\Util\SupportedAddonsLoaderTest::testCallbackReturnsAddonsFromBody
returnArgument() is deprecated and will be removed in PHPUnit 12. Use $double->willReturnArgument() instead of $double->will($this->returnArgument())
```