### PR TITLE
MNT Mock version provider to return predictable version

### DIFF
--- a/tests/Tasks/UpdatePackageInfoTest.php
+++ b/tests/Tasks/UpdatePackageInfoTest.php
@@ -4,12 +4,13 @@ namespace BringYourOwnIdeas\Maintenance\Tests\Tasks;
 
 use BringYourOwnIdeas\Maintenance\Util\ComposerLoader;
 use PHPUnit_Framework_TestCase;
-use RuntimeException;
 use BringYourOwnIdeas\Maintenance\Tasks\UpdatePackageInfoTask;
 use BringYourOwnIdeas\Maintenance\Model\Package;
 use SilverStripe\Core\Manifest\VersionProvider;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SupportedModules\MetaData;
+use BringYourOwnIdeas\UpdateChecker\Extensions\CheckComposerUpdatesExtension;
+use SilverStripe\Core\Injector\Injector;
 
 /**
  * @mixin PHPUnit_Framework_TestCase
@@ -22,6 +23,16 @@ class UpdatePackageInfoTest extends SapphireTest
     {
         parent::setUpBeforeClass();
         MetaData::$isRunningUnitTests = true;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Remove extension that will connect to github
+        // Extension is from bringyourownideas/silverstripe-composer-update-checker
+        if (UpdatePackageInfoTask::has_extension(CheckComposerUpdatesExtension::class)) {
+            UpdatePackageInfoTask::remove_extension(CheckComposerUpdatesExtension::class);
+        }
     }
 
     public function testGetPackageInfo()
@@ -46,30 +57,59 @@ class UpdatePackageInfoTest extends SapphireTest
 
     public function testPackagesAreAddedCorrectly()
     {
-        $task = UpdatePackageInfoTask::create();
+        // Get the latest supported framework version from the MetaData service
+        $data = MetaData::getMetaDataForRepository('silverstripe/silverstripe-framework')['majorVersionMapping'];
+        $keys = array_keys($data);
+        $key = $keys[count($keys) - 1];
+        $latestFrameworkMajor = $data[$key][0];
 
-        $frameworkVersion = VersionProvider::singleton()->getModuleVersion('silverstripe/framework');
-        $composerLoader = $this->getMockBuilder(ComposerLoader::class)
-            ->setMethods(['getLock'])->getMock();
-        $composerLoader->expects($this->any())->method('getLock')->will($this->returnValue(json_decode(<<<LOCK
-{
-    "packages": [
-        {
-            "name": "silverstripe/framework",
-            "description": "A faux package from a mocked composer.lock for testing purposes",
-            "version": "$frameworkVersion"
-        },
-        {
-            "name": "fake/unsupported-package",
-            "description": "A faux package from a mocked composer.lock for testing purposes",
-            "version": "1.0.0"
-        }
-    ],
-    "packages-dev": null
-}
-LOCK
-        )));
-        $task->setComposerLoader($composerLoader);
+        // Mock the VersionProvider service to return the latest framework version
+        Injector::inst()->registerService(new class($latestFrameworkMajor) extends VersionProvider {
+            private $latestFrameworkMajor;
+            public function __construct($latestFrameworkMajor)
+            {
+                $this->latestFrameworkMajor = $latestFrameworkMajor;
+            }
+            public function getModuleVersion(string $module): string
+            {
+                if ($module === 'silverstripe/framework') {
+                    return $this->latestFrameworkMajor . '.0.0';
+                }
+                return parent::getVersion($module);
+            }
+        }, VersionProvider::class);
+
+        // Create a task and mock the ComposerLoader to return a specific composer.lock
+        $task = UpdatePackageInfoTask::create();
+        $task->setComposerLoader(new class($latestFrameworkMajor) extends ComposerLoader {
+            private $latestFrameworkMajor;
+            public function __construct($latestFrameworkMajor)
+            {
+                $this->latestFrameworkMajor = $latestFrameworkMajor;
+            }
+            public function getLock()
+            {
+                return json_decode(
+                    <<<LOCK
+                    {
+                        "packages": [
+                        {
+                            "name": "silverstripe/framework",
+                            "description": "A faux package from a mocked composer.lock for testing purposes",
+                            "version": "{$this->latestFrameworkMajor}.0.0"
+                        },
+                        {
+                            "name": "fake/unsupported-package",
+                            "description": "A faux package from a mocked composer.lock for testing purposes",
+                            "version": "1.0.0"
+                        }
+                        ],
+                        "packages-dev": null
+                    }
+                    LOCK
+                );
+            }
+        });
 
         $task->run(null);
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1697

This is unrelated to the original issue, though fixes a long standing issue of kitchen-sink CI runs failing when there's a forked version of framework. Unit test fails because the forked version isn't commercially supported :-)

This ensure that there's always a predictable version of framework being used, and that github isn't live called during the unit test